### PR TITLE
Allow an environment variable to override installed vagrant plugins

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,26 +1,39 @@
 # Require plugins.
-required_plugins = %w(vagrant-hostsupdater vagrant-auto_network vagrant-cachier)
-plugin_installed = false
-required_plugins.each do |plugin|
-  unless Vagrant.has_plugin?(plugin)
-    system "vagrant plugin install #{plugin}"
-    plugin_installed = true
+local_plugins = ENV['VAGRANT_PLUGINS']
+
+if ("#{local_plugins}" == '' && local_plugins != nil)
+  # Nothing
+else
+  # Define plugins to be installed.
+  if (local_plugins != nil)
+    required_plugins = local_plugins.split
+  else
+    required_plugins = %w(vagrant-hostsupdater vagrant-auto_network vagrant-cachier)
+  end
+
+  plugin_installed = false
+  required_plugins.each do |plugin|
+    unless Vagrant.has_plugin?(plugin)
+      system "vagrant plugin install #{plugin}"
+      plugin_installed = true
+    end
+  end
+
+  # If new plugins installed, restart Vagrant process
+  if plugin_installed === true
+     exec "vagrant #{ARGV.join' '}"
   end
 end
 
-# If new plugins installed, restart Vagrant process
-if plugin_installed === true
-  exec "vagrant #{ARGV.join' '}"
+require 'pathname'
+require 'fileutils'
+if File.exist?('./config.yml')
+  FileUtils.cp('./config.yml', './vendor/geerlingguy/drupal-vm/config.yml');
+end
+if File.exist?('./Vagrantfile.local')
+  FileUtils.cp('./Vagrantfile.local', './vendor/geerlingguy/drupal-vm/Vagrantfile.local');
 end
 
-# The absolute path to the root directory of the project. Both Drupal VM and
-# the config file need to be contained within this path.
-ENV['DRUPALVM_PROJECT_ROOT'] = "#{__dir__}"
-# The relative path from the project root to the config directory where you
-# placed your config.yml file.
-ENV['DRUPALVM_CONFIG_DIR'] = "."
-# The relative path from the project root to the directory where Drupal VM is located.
-ENV['DRUPALVM_DIR'] = "vendor/geerlingguy/drupal-vm"
-
 # Load the real Vagrantfile
-load "#{__dir__}/#{ENV['DRUPALVM_DIR']}/Vagrantfile"
+dir = File.dirname(__FILE__) + '/'
+load dir + "vendor/geerlingguy/drupal-vm/Vagrantfile"


### PR DESCRIPTION
## [PROJECT-XX: Title](https://fourkitchens.atlassian.net/browse/PROJECT-XX)

**This PR does the following:**
- Allow an environment variable to override installed vagrant plugins

### To Review:

- [ ] Checkout this branch
- [ ] Run `vagrant up`
- [ ] Verify it isn't broken
- [ ] This also allows you to set plugins as an environment variable rather than requiring the use of specific plugins.
